### PR TITLE
Disable v1 compat for #4

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -16,5 +16,8 @@
     "testFiles": [
         "test.ts"
     ],
+    "disablesVariants": [
+        "mbdal"
+    ],
     "public": true
 }


### PR DESCRIPTION
Disable V1 compatibility for #4. Prevents the library bailing with a cryptic error.

Should - perhaps - investigate a pixel-doubled port of this library to run on V1.